### PR TITLE
use project PHID for ticket lookups in phabricator

### DIFF
--- a/phalerts.py
+++ b/phalerts.py
@@ -149,7 +149,7 @@ def find_task(title, projects):
         constraints=dict(
             query='title:"%s"' % title,
             statuses=["open"],
-            projects=projects,
+            projects=list(project_phids),
         ),
         attachments=dict(projects=True),
         # this expands to "title, id", so we'll get the newest open task if
@@ -168,6 +168,7 @@ def find_task(title, projects):
         # Check that the task has all required projects assigned to it.
         if not project_phids.issubset(task_projects):
             continue
+
         return task
 
 def process_task(title, description, projects):


### PR DESCRIPTION
Lookup of phabricator ticket doesn't work correctly with project name which contains space. On other hand it works when using project PHIDs.